### PR TITLE
イニシャルユーザー限定の新規登録フローに変更

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ from flask import Flask
 
 from config import Config
 from extensions import db, login_manager
+from models import User
 from views.auth import auth_bp
 from views.main import main_bp
 
@@ -20,9 +21,34 @@ def create_app() -> Flask:
 
     with app.app_context():
         db.create_all()
+        ensure_initial_user(app)
 
     register_blueprints(app)
     return app
+
+
+def ensure_initial_user(app: Flask) -> None:
+    """環境変数からイニシャルユーザーを作成する。"""
+
+    username = app.config.get("INITIAL_USER_USERNAME")
+    email = app.config.get("INITIAL_USER_EMAIL")
+    password = app.config.get("INITIAL_USER_PASSWORD")
+    if not username or not email or not password:
+        app.logger.info("イニシャルユーザーの環境変数が未設定のため作成をスキップしました。")
+        return
+
+    if User.query.filter((User.username == username) | (User.email == email)).first():
+        return
+
+    if User.query.first() is not None:
+        app.logger.warning("既存ユーザーが存在するためイニシャルユーザーの作成をスキップしました。")
+        return
+
+    user = User(username=username, email=email)
+    user.set_password(password)
+    db.session.add(user)
+    db.session.commit()
+    app.logger.info("イニシャルユーザーを作成しました。")
 
 
 def register_blueprints(app: Flask) -> None:

--- a/config.py
+++ b/config.py
@@ -16,3 +16,6 @@ class Config:
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     MAX_CONTENT_LENGTH = int(os.environ.get("MAX_CONTENT_LENGTH", str(128 * 1024 * 1024)))
     MAX_FORM_MEMORY_SIZE = int(os.environ.get("MAX_FORM_MEMORY_SIZE", str(128 * 1024 * 1024)))
+    INITIAL_USER_USERNAME = os.environ.get("INITIAL_USER_USERNAME")
+    INITIAL_USER_EMAIL = os.environ.get("INITIAL_USER_EMAIL")
+    INITIAL_USER_PASSWORD = os.environ.get("INITIAL_USER_PASSWORD")

--- a/models.py
+++ b/models.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Optional
 
+from flask import current_app
 from flask_login import UserMixin
 from werkzeug.security import check_password_hash, generate_password_hash
 
@@ -31,6 +32,16 @@ class User(db.Model, UserMixin):
         """入力パスワードと保存済みハッシュを照合する。"""
 
         return check_password_hash(self.password_hash, raw_password)
+
+    @property
+    def is_initial_user(self) -> bool:
+        """イニシャルユーザーかどうかを判定する。"""
+
+        username = current_app.config.get("INITIAL_USER_USERNAME")
+        email = current_app.config.get("INITIAL_USER_EMAIL")
+        if not username or not email:
+            return False
+        return self.username == username and self.email == email
 
 
 class IllustrationPreset(db.Model):

--- a/templates/base.html
+++ b/templates/base.html
@@ -18,10 +18,12 @@
         <div class="d-flex align-items-center gap-2 ms-auto">
           {% if current_user.is_authenticated %}
           <span class="badge rounded-pill bg-light text-dark me-1"><i class="bi bi-person"></i> {{ current_user.username }} さん</span>
+          {% if current_user.is_initial_user %}
+          <a class="btn btn-primary me-2" href="{{ url_for('auth.signup') }}">新規登録</a>
+          {% endif %}
           <a class="btn btn-outline-light" href="{{ url_for('auth.logout') }}">ログアウト</a>
           {% else %}
           <a class="btn btn-outline-light me-2" href="{{ url_for('auth.login') }}">ログイン</a>
-          <a class="btn btn-primary" href="{{ url_for('auth.signup') }}">新規登録</a>
           {% endif %}
         </div>
       </div>

--- a/templates/login.html
+++ b/templates/login.html
@@ -9,6 +9,7 @@
             <div class="badge badge-soft mb-2">サインイン</div>
             <h2 class="card-title mb-1">ようこそ、おかえりなさい</h2>
             <p class="subtle-text mb-0">登録済みのユーザー名とパスワードでログインしてください。</p>
+            <p class="subtle-text mb-0">新規登録はイニシャルユーザーがログインした状態でのみ実行できます。</p>
           </div>
           <i class="bi bi-door-open fs-2 text-info"></i>
         </div>
@@ -29,7 +30,6 @@
           </div>
           <div class="d-grid gap-2 d-md-flex justify-content-md-between align-items-center">
             <button class="btn btn-primary px-4" type="submit">ログイン</button>
-            <a class="text-decoration-none subtle-text" href="{{ url_for('auth.signup') }}">新規登録はこちら</a>
           </div>
         </form>
       </div>

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -9,6 +9,7 @@
             <div class="badge badge-soft mb-2">無料で登録</div>
             <h2 class="card-title mb-1">新しいクリエイティブをはじめよう</h2>
             <p class="subtle-text mb-0">ユーザー名・メール・パスワードを設定してアカウントを作成します。</p>
+            <p class="subtle-text mb-0">イニシャルユーザーとしてログイン中のみ登録できます。</p>
           </div>
           <i class="bi bi-stars fs-2 text-warning"></i>
         </div>

--- a/views/auth.py
+++ b/views/auth.py
@@ -20,7 +20,12 @@ def _get_next_url() -> Optional[str]:
 
 @auth_bp.route("/signup", methods=["GET", "POST"])
 def signup():
-    if current_user.is_authenticated:
+    if not current_user.is_authenticated:
+        flash("新規登録はイニシャルユーザーでログインした場合のみ利用できます。", "error")
+        return redirect(url_for("auth.login"))
+
+    if not current_user.is_initial_user:
+        flash("新規登録はイニシャルユーザーのみ利用できます。", "error")
         return redirect(url_for("main.index"))
 
     if request.method == "POST":
@@ -40,7 +45,6 @@ def signup():
         user.set_password(password)
         db.session.add(user)
         db.session.commit()
-        login_user(user)
         flash("ユーザー登録が完了しました。", "success")
         return redirect(url_for("main.index"))
 


### PR DESCRIPTION
### Motivation

- 新規ユーザー登録をイニシャルユーザー経由のみに制限し、登録フローを管理者がコントロールできるようにすることでセキュリティを強化します。 
- イニシャルユーザー情報を環境変数から読み取るようにして、デプロイ環境ごとに設定可能にします。 
- 管理者（イニシャルユーザー）以外が意図せず新規登録できないようにUI上の誘導も合わせて変更します。 

### Description

- `config.py` に `INITIAL_USER_USERNAME` / `INITIAL_USER_EMAIL` / `INITIAL_USER_PASSWORD` の設定を追加し、環境変数から読み取るようにしました。 
- `app.py` に `ensure_initial_user(app)` を追加して、アプリ初回起動時に環境変数に基づくイニシャルユーザーを自動作成する処理を実装しました。 
- `models.py` に `User.is_initial_user` プロパティを追加して、現在のユーザーがイニシャルユーザーか判定できるようにしました。 
- `views/auth.py` とテンプレート（`templates/base.html` / `templates/login.html` / `templates/signup.html`）を更新して、サインアップ操作をイニシャルユーザーのみ許可し、一般ユーザーからの新規登録リンクを非表示／文言変更しました。 

### Testing

- `python app.py` および `FLASK_APP=app flask run` を環境変数 `INITIAL_USER_USERNAME=admin INITIAL_USER_EMAIL=admin@example.com INITIAL_USER_PASSWORD=adminpass` を指定して起動する試行を行い、サーバープロセスは起動することを確認しました。 
- ブラウザ自動化で `http://localhost:5000/login` のスクリーンショット取得を試みましたが、`net::ERR_EMPTY_RESPONSE` により接続できず失敗しました。 
- ユニットテスト等の自動テストは追加しておらず未実行です。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6953bc9dcc408326a939ed77a12b479a)