### PR TITLE
Add GUI chat mode with menu integration and chat history

### DIFF
--- a/.agent/EXEC_PLAN_CHAT_GUI.md
+++ b/.agent/EXEC_PLAN_CHAT_GUI.md
@@ -1,0 +1,78 @@
+# GUIチャットモードを追加し既存モードをメニュー経由で利用できるようにする
+
+このExecPlanは生きたドキュメントです。`Progress`、`Surprises & Discoveries`、`Decision Log`、`Outcomes & Retrospective`の各セクションは作業の進行に合わせて常に更新する必要があります。
+
+このリポジトリのルートにPLANS.mdが存在するため、本ドキュメントは`PLANS.md`に従って更新・維持します。
+
+## Purpose / Big Picture
+
+ユーザーがGUI上でテキストと画像を混ぜたチャット形式のやり取りを行い、既存の生成・編集機能をチャットのメニューから呼び出せるようにします。実装後は、同じページで「モード切替」からチャットモードを選び、会話履歴を保持したままテキストチャットやラフ→仕上げ、参照着色、インペイント/アウトペイントを実行できることを確認できます。
+
+## Progress
+
+- [x] (2025-10-02 01:10Z) 既存のモード定義・テンプレート・JSの構成を調査し、チャットモードに必要な差分を洗い出す。
+- [x] (2025-10-02 01:40Z) チャット履歴をセッションに保存し、Gemini向けのテキスト応答生成ロジックを追加する。
+- [x] (2025-10-02 02:15Z) チャットUI（会話履歴表示、入力欄、メニュー選択、追加フォーム）を実装し、既存モードをメニュー経由で実行できるようにする。
+- [x] (2025-10-02 02:40Z) 既存の生成・編集機能とチャットモードの連携を仕上げ、テストを追加する。
+- [x] (2025-10-02 03:10Z) 動作確認・テスト実行・スクリーンショット取得を行い、ExecPlanの更新を完了する。
+
+## Surprises & Discoveries
+
+- Observation: pytest実行時にSQLAlchemyのLegacyAPIWarningが発生したが、挙動自体は問題なくテストは完了した。
+  Evidence: pytest実行ログにLegacyAPIWarningが出力された。
+
+- Observation: スクリーンショット取得時はFlaskのデバッグ起動では接続が不安定だったため、0.0.0.0の通常起動で撮影した。
+  Evidence: playwrightのERR_EMPTY_RESPONSEを回避するため起動方法を変更した。
+
+## Decision Log
+
+- Decision: チャット履歴はセッションに「画像IDのみ」を保存し、画像本体は既存の一時保存ディレクトリへ格納する方式を採用する。
+  Rationale: クッキーサイズ制限を避け、既存の画像保存ロジックと整合させるため。
+  Date/Author: 2025-10-02 / Agent
+
+- Decision: チャットモードの編集はマスク画像のアップロードで行い、専用のエディタは追加しない。
+  Rationale: 既存UIを壊さずにメニュー経由で編集機能を使えることを優先し、実装コストを抑えるため。
+  Date/Author: 2025-10-02 / Agent
+
+## Outcomes & Retrospective
+
+チャットモードはテキスト会話と既存の画像生成/編集メニューを統合し、会話履歴を保持できるようになった。今後はチャット専用のマスクエディタ統合や履歴の永続化が追加改善ポイントとなる。
+
+## Context and Orientation
+
+Flaskアプリは`app.py`の`create_app`で初期化され、`views/main.py`の`index`がメイン画面を描画します。モード定義は`services/modes.py`にあり、`templates/index.html`と`static/js/index.js`でフォーム表示の切替を行います。生成処理は`services/generation_service.py`が担い、Gemini API連携は`illust.py`にまとまっています。チャットモードは新しいGenerationModeとして追加し、GUIは既存のモードUIを残したまま追加する必要があります。
+
+## Plan of Work
+
+まず`services/modes.py`にチャット用の`GenerationMode`を追加し、`views/main.py`の`index`でチャット用POST処理を分岐できるようにする。次に`illust.py`にテキスト応答生成関数を追加し、`services/chat_service.py`（新規）でセッション履歴の保存・読み出し・Gemini向けコンテンツ構築を行う。`templates/index.html`にチャットUI（会話履歴、入力欄、メニュー、モード別入力欄）を追加し、`static/js/index.js`でチャットメニューの選択や表示切替を制御する。最後にpytestベースのテストを追加し、チャットモードと既存モードの分岐が壊れていないことを確認する。
+
+## Concrete Steps
+
+`/workspace/rough_to_illustration`で作業を行う。
+
+1. `services/modes.py`にチャットモード定義を追加する。
+2. `illust.py`にテキストチャット用のGemini呼び出し関数を追加し、レスポンスからテキストを抽出する。
+3. `services/chat_service.py`を新規作成し、セッションにチャット履歴を保存するヘルパーと、履歴からGemini入力を構築する関数を実装する。
+4. `views/main.py`にチャットモードのPOST処理（テキストチャット、既存モード実行、履歴クリア）を追加し、テンプレートへチャット履歴を渡す。
+5. `templates/index.html`にチャットUIを追加し、既存のフォームは削除せずに切替対象として残す。
+6. `static/js/index.js`にチャットモードのメニュー選択やフォーム切替処理を追加する。
+7. `tests/`配下にpytestテストを追加し、チャットモードのGET/POSTと既存モードの分岐が動くことを確認する。
+8. テストを実行し、必要なら調整する。
+
+## Validation and Acceptance
+
+アプリを起動してログイン後、モード選択で「チャット（GUI）」を選択できることを確認する。チャット画面でテキストを送信すると履歴に追加され、次の送信で履歴が保持されていることを確認する。メニューから既存モードを選択し、必要な画像やテキストを入力して送信すると、チャット履歴に画像生成結果が表示されることを確認する。`pytest`を実行し、新規テストがパスすることを確認する。
+
+## Idempotence and Recovery
+
+チャット履歴の初期化は「履歴クリア」操作で行い、何度でも安全に実行できるようにする。画像保存は既存の一時保存パスを再利用し、不要な画像は適宜削除する。問題が起きた場合はチャット履歴を削除して再実行できる。
+
+## Artifacts and Notes
+
+主要な変更は`services/chat_service.py`と`templates/index.html`、`views/main.py`に集中している。pytest実行ログで5件のテストが成功したことを確認し、`chat_mode.png`でGUIの見た目を記録した。
+
+## Interfaces and Dependencies
+
+`illust.py`にテキスト応答生成関数`generate_chat_response`を追加する。`services/chat_service.py`に`load_chat_history`、`save_chat_history`、`append_chat_message`、`build_chat_contents`などの関数を追加する。`views/main.py`の`index`にチャットモード分岐を追加し、チャット用フォームの入力名を明記する。依存ライブラリとしてpytestを`requirements.txt`に追加する。
+
+変更履歴: 2025-10-02 / Agent により進捗・意思決定・発見事項を更新。

--- a/app.py
+++ b/app.py
@@ -9,11 +9,13 @@ from views.auth import auth_bp
 from views.main import main_bp
 
 
-def create_app() -> Flask:
+def create_app(config_override: dict | None = None) -> Flask:
     """Flaskアプリケーションを生成し、Blueprintを登録する。"""
 
     app = Flask(__name__)
     app.config.from_object(Config)
+    if config_override:
+        app.config.update(config_override)
 
     db.init_app(app)
     login_manager.init_app(app)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ Flask-SQLAlchemy
 Pillow
 google-genai
 python-dotenv
+pytest

--- a/services/chat_service.py
+++ b/services/chat_service.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, Optional
+
+from flask import session
+from PIL import Image
+
+from services.generation_service import load_image_path_from_storage
+
+
+DEFAULT_CHAT_SYSTEM_PROMPT = (
+    "あなたはイラスト制作の相談に乗るアシスタントです。"
+    "会話履歴を参照しつつ、簡潔でわかりやすい日本語で返答してください。"
+)
+
+
+@dataclass(frozen=True)
+class ChatImage:
+    """チャットメッセージに紐づく画像情報。"""
+
+    image_id: str
+    mime_type: str
+    label: str = ""
+
+
+@dataclass(frozen=True)
+class ChatMessage:
+    """チャットのメッセージデータ。"""
+
+    role: str
+    text: str
+    images: list[ChatImage] = field(default_factory=list)
+
+
+def _serialize_message(message: ChatMessage) -> dict:
+    return {
+        "role": message.role,
+        "text": message.text,
+        "images": [
+            {"image_id": image.image_id, "mime_type": image.mime_type, "label": image.label}
+            for image in message.images
+        ],
+    }
+
+
+def _deserialize_message(raw: dict) -> ChatMessage:
+    images = [
+        ChatImage(
+            image_id=image.get("image_id", ""),
+            mime_type=image.get("mime_type", "image/png"),
+            label=image.get("label", ""),
+        )
+        for image in raw.get("images", [])
+        if image.get("image_id")
+    ]
+    return ChatMessage(
+        role=raw.get("role", "user"),
+        text=raw.get("text", ""),
+        images=images,
+    )
+
+
+def load_chat_history() -> list[ChatMessage]:
+    """セッションに保存したチャット履歴を取得する。"""
+
+    raw_history = session.get("chat_history", [])
+    if not isinstance(raw_history, list):
+        return []
+    return [_deserialize_message(item) for item in raw_history if isinstance(item, dict)]
+
+
+def save_chat_history(history: Iterable[ChatMessage]) -> None:
+    """チャット履歴をセッションに保存する。"""
+
+    session["chat_history"] = [_serialize_message(message) for message in history]
+
+
+def clear_chat_history() -> None:
+    """チャット履歴をクリアする。"""
+
+    session.pop("chat_history", None)
+
+
+def append_chat_message(
+    history: list[ChatMessage],
+    message: ChatMessage,
+    *,
+    max_messages: int = 24,
+) -> list[ChatMessage]:
+    """チャット履歴にメッセージを追加し、上限件数でトリムする。"""
+
+    updated = [*history, message]
+    if len(updated) > max_messages:
+        updated = updated[-max_messages:]
+    save_chat_history(updated)
+    return updated
+
+
+def build_chat_contents(
+    history: list[ChatMessage],
+    *,
+    system_prompt: str = DEFAULT_CHAT_SYSTEM_PROMPT,
+) -> list[object]:
+    """Geminiに渡すチャットコンテンツを構築する。"""
+
+    contents: list[object] = []
+    if system_prompt:
+        contents.append(system_prompt)
+
+    for message in history:
+        role_label = "ユーザー" if message.role == "user" else "アシスタント"
+        text = message.text.strip() or "（内容なし）"
+        contents.append(f"{role_label}: {text}")
+        if message.role == "user":
+            contents.extend(_load_message_images(message))
+
+    return contents
+
+
+def _load_message_images(message: ChatMessage) -> list[Image.Image]:
+    images: list[Image.Image] = []
+    for image_info in message.images:
+        path = load_image_path_from_storage(image_info.image_id)
+        if not path or not path.exists():
+            continue
+        try:
+            image = Image.open(path)
+            image.load()
+        except Exception:
+            continue
+        images.append(image)
+    return images
+
+
+def build_user_message(
+    *,
+    text: str,
+    images: Optional[list[ChatImage]] = None,
+) -> ChatMessage:
+    """ユーザー発話用のメッセージを生成する。"""
+
+    return ChatMessage(role="user", text=text, images=images or [])
+
+
+def build_assistant_message(
+    text: str,
+    *,
+    images: Optional[list[ChatImage]] = None,
+) -> ChatMessage:
+    """アシスタント発話用のメッセージを生成する。"""
+
+    return ChatMessage(role="assistant", text=text, images=images or [])

--- a/services/modes.py
+++ b/services/modes.py
@@ -33,10 +33,17 @@ MODE_INPAINT_OUTPAINT = GenerationMode(
     enabled=True,
 )
 
+MODE_CHAT_GUI = GenerationMode(
+    id="chat_gui",
+    label="チャット（GUI）",
+    description="テキストと画像を使って会話しながら生成・編集できます。",
+)
+
 ALL_MODES: list[GenerationMode] = [
     MODE_ROUGH_WITH_INSTRUCTIONS,
     MODE_REFERENCE_STYLE_COLORIZE,
     MODE_INPAINT_OUTPAINT,
+    MODE_CHAT_GUI,
 ]
 
 DEFAULT_MODE_ID: str = MODE_ROUGH_WITH_INSTRUCTIONS.id
@@ -49,4 +56,3 @@ def normalize_mode_id(mode_id: Optional[str]) -> str:
         if mode.enabled and mode.id == mode_id:
             return mode.id
     return DEFAULT_MODE_ID
-

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -160,3 +160,72 @@
   border-color: rgba(31, 209, 249, 0.35);
   color: #b8ecff;
 }
+
+.chat-panel {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 14px;
+  padding: 16px;
+}
+
+.chat-history {
+  max-height: 420px;
+  overflow-y: auto;
+  padding-right: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.chat-message {
+  padding: 12px 14px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.chat-message.chat-user {
+  align-self: flex-end;
+  background: rgba(31, 209, 249, 0.12);
+  border-color: rgba(31, 209, 249, 0.25);
+}
+
+.chat-message.chat-assistant {
+  align-self: flex-start;
+}
+
+.chat-message-header {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.85rem;
+  color: #c9d4ff;
+  margin-bottom: 6px;
+}
+
+.chat-message-text {
+  line-height: 1.5;
+  white-space: normal;
+}
+
+.chat-message-images {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.chat-image {
+  margin: 0;
+}
+
+.chat-image img {
+  max-width: 220px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.chat-image figcaption {
+  font-size: 0.75rem;
+  color: #b6c1e8;
+  margin-top: 4px;
+}

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -249,6 +249,59 @@ const initSubmitState = () => {
   });
 };
 
+const CHAT_MENU_LABELS = {
+  text: 'テキストチャット',
+  rough_with_instructions: 'ラフ→仕上げ（色・ポーズ指示）',
+  reference_style_colorize: '完成絵参照→ラフ着色',
+  inpaint_outpaint: 'インペイント/アウトペイント編集',
+};
+
+const initChatMenu = () => {
+  const actionInput = document.getElementById('chatActionInput');
+  const modeInput = document.getElementById('chatModeInput');
+  const menuLabel = document.getElementById('chatMenuLabel');
+  const panels = document.querySelectorAll('[data-chat-panel]');
+  const menuItems = document.querySelectorAll('[data-chat-action]');
+
+  if (!actionInput || !modeInput || !menuLabel || panels.length === 0 || menuItems.length === 0) return;
+
+  const applyChatAction = (action) => {
+    const isText = action === 'text';
+    actionInput.value = isText ? 'text' : 'generate';
+    modeInput.value = isText ? 'rough_with_instructions' : action;
+    menuLabel.textContent = CHAT_MENU_LABELS[action] || CHAT_MENU_LABELS.text;
+
+    panels.forEach((panel) => {
+      panel.classList.toggle('d-none', panel.dataset.chatPanel !== action);
+    });
+  };
+
+  menuItems.forEach((item) => {
+    item.addEventListener('click', () => {
+      const action = item.dataset.chatAction;
+      if (!action) return;
+      applyChatAction(action);
+    });
+  });
+
+  applyChatAction('text');
+};
+
+const initChatSubmitState = () => {
+  const form = document.getElementById('chatForm');
+  const submitBtn = document.getElementById('chatSubmitButton');
+  const spinner = document.getElementById('chatLoadingSpinner');
+  const submitLabel = document.getElementById('chatSubmitLabel');
+
+  if (!form || !submitBtn || !spinner || !submitLabel) return;
+
+  form.addEventListener('submit', () => {
+    submitBtn.disabled = true;
+    spinner.classList.remove('d-none');
+    submitLabel.textContent = '送信中...';
+  });
+};
+
 const initPresets = () => {
   const panel = document.getElementById('presetPanel');
   const presetSelect = document.getElementById('presetSelect');
@@ -516,6 +569,8 @@ const bootstrapIndexPage = () => {
   initSubmitState();
   initPresets();
   initMaskEditor();
+  initChatMenu();
+  initChatSubmitState();
 };
 
 document.addEventListener('DOMContentLoaded', bootstrapIndexPage);

--- a/templates/index.html
+++ b/templates/index.html
@@ -103,7 +103,177 @@
           </form>
         </div>
 
-        <form id="generateForm" method="post" enctype="multipart/form-data" class="d-flex flex-column gap-3">
+        <div class="chat-panel d-none" data-mode-visible="chat_gui">
+          <div class="d-flex justify-content-between align-items-start flex-wrap gap-2">
+            <div>
+              <h5 class="mb-1">チャット</h5>
+              <small class="text-white-50">テキストと画像で会話しながら生成・編集できます。</small>
+            </div>
+            <form method="post" class="ms-auto">
+              <input type="hidden" name="mode" value="{{ current_mode }}">
+              <input type="hidden" name="chat_action" value="clear">
+              <button class="btn btn-outline-light btn-sm" type="submit"><i class="bi bi-trash3 me-1"></i> 履歴クリア</button>
+            </form>
+          </div>
+
+          <div class="chat-history mt-3" id="chatHistory">
+            {% if chat_history %}
+              {% for message in chat_history %}
+              <div class="chat-message {% if message.role == 'user' %}chat-user{% else %}chat-assistant{% endif %}">
+                <div class="chat-message-header">
+                  <span class="chat-role">{{ 'あなた' if message.role == 'user' else 'アシスタント' }}</span>
+                </div>
+                {% if message.text %}
+                <div class="chat-message-text">{{ message.text | replace('\n', '<br>') | safe }}</div>
+                {% endif %}
+                {% if message.images %}
+                <div class="chat-message-images">
+                  {% for image in message.images %}
+                  <figure class="chat-image">
+                    <img src="{{ image.data_uri }}" alt="{{ image.label or 'チャット画像' }}">
+                    {% if image.label %}
+                    <figcaption>{{ image.label }}</figcaption>
+                    {% endif %}
+                  </figure>
+                  {% endfor %}
+                </div>
+                {% endif %}
+              </div>
+              {% endfor %}
+            {% else %}
+            <div class="text-white-50 small">まだ会話がありません。テキストや画像を送信すると履歴が表示されます。</div>
+            {% endif %}
+          </div>
+
+          <form id="chatForm" method="post" enctype="multipart/form-data" class="d-flex flex-column gap-3 mt-3">
+            <input type="hidden" name="mode" value="{{ current_mode }}">
+            <input type="hidden" name="chat_action" id="chatActionInput" value="text">
+            <input type="hidden" name="chat_mode" id="chatModeInput" value="rough_with_instructions">
+
+            <div class="chat-menu d-flex flex-wrap align-items-center gap-2">
+              <div class="dropdown">
+                <button class="btn btn-outline-light dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+                  <i class="bi bi-chat-dots me-1"></i> メニュー
+                </button>
+                <ul class="dropdown-menu dropdown-menu-dark">
+                  <li><button class="dropdown-item" type="button" data-chat-action="text">テキストチャット</button></li>
+                  <li><button class="dropdown-item" type="button" data-chat-action="rough_with_instructions">ラフ→仕上げ（色・ポーズ指示）</button></li>
+                  <li><button class="dropdown-item" type="button" data-chat-action="reference_style_colorize">完成絵参照→ラフ着色</button></li>
+                  <li><button class="dropdown-item" type="button" data-chat-action="inpaint_outpaint">インペイント/アウトペイント編集</button></li>
+                </ul>
+              </div>
+              <span class="badge badge-soft" id="chatMenuLabel">テキストチャット</span>
+              <span class="text-white-50 small">メニューから実行モードを切り替えられます。</span>
+            </div>
+
+            <div class="chat-action-panel" data-chat-panel="text">
+              <label class="form-label" for="chat_message">メッセージ</label>
+              <textarea class="form-control" id="chat_message" name="chat_message" rows="3" maxlength="1200" placeholder="例: 背景の雰囲気をもう少し柔らかくしたいです。"></textarea>
+              <div class="d-flex flex-wrap align-items-center gap-2 mt-2">
+                <label class="btn btn-outline-light btn-sm" for="chat_image"><i class="bi bi-image me-1"></i> 画像を添付</label>
+                <input class="visually-hidden" type="file" id="chat_image" name="chat_image" accept="image/png, image/jpeg">
+                <small class="text-white-50">画像とテキストを同時に送れます。</small>
+              </div>
+            </div>
+
+            <div class="chat-action-panel d-none" data-chat-panel="rough_with_instructions">
+              <div class="row g-3">
+                <div class="col-md-6">
+                  <label class="form-label" for="chat_rough_image">ラフスケッチ</label>
+                  <input class="form-control" type="file" id="chat_rough_image" name="chat_rough_image" accept="image/png, image/jpeg">
+                </div>
+                <div class="col-md-6">
+                  <label class="form-label" for="chat_color_instruction">着色イメージ</label>
+                  <textarea class="form-control" id="chat_color_instruction" name="chat_color_instruction" rows="2" maxlength="1000"></textarea>
+                </div>
+                <div class="col-md-6">
+                  <label class="form-label" for="chat_pose_instruction">ポーズの指示</label>
+                  <textarea class="form-control" id="chat_pose_instruction" name="chat_pose_instruction" rows="2" maxlength="1000"></textarea>
+                </div>
+                <div class="col-md-3">
+                  <label class="form-label" for="chat_aspect_ratio">アスペクト比</label>
+                  <select class="form-select" id="chat_aspect_ratio" name="chat_aspect_ratio">
+                    {% for label in aspect_ratio_options %}
+                    <option value="{{ label }}">{{ '自動' if label == 'auto' else label }}</option>
+                    {% endfor %}
+                  </select>
+                </div>
+                <div class="col-md-3">
+                  <label class="form-label" for="chat_resolution">解像度</label>
+                  <select class="form-select" id="chat_resolution" name="chat_resolution">
+                    {% for label in resolution_options %}
+                    <option value="{{ label }}">{{ '自動' if label == 'auto' else label }}</option>
+                    {% endfor %}
+                  </select>
+                </div>
+              </div>
+            </div>
+
+            <div class="chat-action-panel d-none" data-chat-panel="reference_style_colorize">
+              <div class="row g-3">
+                <div class="col-md-6">
+                  <label class="form-label" for="chat_reference_image">参考（完成）画像</label>
+                  <input class="form-control" type="file" id="chat_reference_image" name="chat_reference_image" accept="image/png, image/jpeg">
+                </div>
+                <div class="col-md-6">
+                  <label class="form-label" for="chat_reference_rough_image">ラフスケッチ</label>
+                  <input class="form-control" type="file" id="chat_reference_rough_image" name="chat_rough_image" accept="image/png, image/jpeg">
+                </div>
+                <div class="col-md-3">
+                  <label class="form-label" for="chat_reference_aspect_ratio">アスペクト比</label>
+                  <select class="form-select" id="chat_reference_aspect_ratio" name="chat_aspect_ratio">
+                    {% for label in aspect_ratio_options %}
+                    <option value="{{ label }}">{{ '自動' if label == 'auto' else label }}</option>
+                    {% endfor %}
+                  </select>
+                </div>
+                <div class="col-md-3">
+                  <label class="form-label" for="chat_reference_resolution">解像度</label>
+                  <select class="form-select" id="chat_reference_resolution" name="chat_resolution">
+                    {% for label in resolution_options %}
+                    <option value="{{ label }}">{{ '自動' if label == 'auto' else label }}</option>
+                    {% endfor %}
+                  </select>
+                </div>
+              </div>
+            </div>
+
+            <div class="chat-action-panel d-none" data-chat-panel="inpaint_outpaint">
+              <div class="row g-3">
+                <div class="col-md-6">
+                  <label class="form-label" for="chat_edit_base_image">編集対象画像</label>
+                  <input class="form-control" type="file" id="chat_edit_base_image" name="chat_edit_base_image" accept="image/png, image/jpeg">
+                </div>
+                <div class="col-md-6">
+                  <label class="form-label" for="chat_edit_mask_image">マスク画像</label>
+                  <input class="form-control" type="file" id="chat_edit_mask_image" name="chat_edit_mask_image" accept="image/png, image/jpeg">
+                </div>
+                <div class="col-md-4">
+                  <label class="form-label" for="chat_edit_mode">編集モード</label>
+                  <select class="form-select" id="chat_edit_mode" name="chat_edit_mode">
+                    <option value="inpaint">インペイント</option>
+                    <option value="outpaint">アウトペイント</option>
+                  </select>
+                </div>
+                <div class="col-md-8">
+                  <label class="form-label" for="chat_edit_instruction">追加指示</label>
+                  <textarea class="form-control" id="chat_edit_instruction" name="chat_edit_instruction" rows="2" maxlength="1000"></textarea>
+                </div>
+              </div>
+              <small class="text-white-50 d-block mt-2">マスク画像は編集したい領域が白、その他が黒の画像を用意してください。</small>
+            </div>
+
+            <div class="d-grid d-md-flex align-items-center gap-3">
+              <button class="btn btn-primary flex-grow-1" id="chatSubmitButton" type="submit">
+                <span class="spinner-border spinner-border-sm me-2 d-none" id="chatLoadingSpinner" aria-hidden="true"></span>
+                <span id="chatSubmitLabel">送信</span>
+              </button>
+              <div class="text-white-50 small"><i class="bi bi-lightbulb me-1"></i> 送信中はボタンが無効化されます。</div>
+            </div>
+          </form>
+        </div>
+
+        <form id="generateForm" method="post" enctype="multipart/form-data" class="d-flex flex-column gap-3" data-mode-visible="rough_with_instructions,reference_style_colorize,inpaint_outpaint">
           <input type="hidden" name="mode" id="generationModeInput" value="{{ current_mode }}">
 
           <div class="d-flex flex-column flex-md-row gap-3">
@@ -289,6 +459,9 @@
         </p>
         <p class="subtle-text mb-0 {% if current_mode != 'inpaint_outpaint' %}d-none{% endif %}" data-mode-visible="inpaint_outpaint">
           編集対象画像をアップロードしてマスクを描き、「編集をリクエスト」を押すと、ここにプレビューが表示されます。
+        </p>
+        <p class="subtle-text mb-0 {% if current_mode != 'chat_gui' %}d-none{% endif %}" data-mode-visible="chat_gui">
+          チャットのやり取りで生成された画像はここに表示され、履歴にはテキストと画像が残ります。
         </p>
         {% endif %}
       </div>

--- a/tests/test_chat_mode.py
+++ b/tests/test_chat_mode.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+from io import BytesIO
+from pathlib import Path
+import sys
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT_DIR))
+
+from app import create_app
+from extensions import db
+from models import User
+from services.generation_service import GenerationResult
+
+
+@pytest.fixture()
+def app():
+    app = create_app(
+        {
+            "TESTING": True,
+            "SQLALCHEMY_DATABASE_URI": "sqlite://",
+            "INITIAL_USER_USERNAME": None,
+            "INITIAL_USER_EMAIL": None,
+            "INITIAL_USER_PASSWORD": None,
+            "SECRET_KEY": "test-secret",
+        }
+    )
+    with app.app_context():
+        db.create_all()
+        user = User(username="tester", email="tester@example.com")
+        user.set_password("password")
+        db.session.add(user)
+        db.session.commit()
+    yield app
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+def login(client):
+    return client.post(
+        "/login",
+        data={"username": "tester", "password": "password"},
+        follow_redirects=True,
+    )
+
+
+def test_chat_text_action(monkeypatch, client):
+    login(client)
+
+    def fake_generate_chat_response(*, contents):
+        assert contents
+        return "テスト応答"
+
+    monkeypatch.setattr("views.main.generate_chat_response", fake_generate_chat_response)
+
+    response = client.post(
+        "/",
+        data={
+            "mode": "chat_gui",
+            "chat_action": "text",
+            "chat_message": "こんにちは",
+        },
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert "テスト応答" in response.get_data(as_text=True)
+
+
+def test_chat_generate_rough(monkeypatch, client):
+    login(client)
+
+    fake_result = GenerationResult(
+        image_data_uri="data:image/png;base64,AAAA",
+        mime_type="image/png",
+        image_id="fake-image-id",
+    )
+
+    monkeypatch.setattr("views.main.run_generation", lambda **kwargs: fake_result)
+
+    response = client.post(
+        "/",
+        data={
+            "mode": "chat_gui",
+            "chat_action": "generate",
+            "chat_mode": "rough_with_instructions",
+            "chat_color_instruction": "色指定",
+            "chat_pose_instruction": "ポーズ指定",
+        },
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert "画像生成が完了しました。" in response.get_data(as_text=True)
+
+
+def test_chat_generate_reference(monkeypatch, client):
+    login(client)
+
+    fake_result = GenerationResult(
+        image_data_uri="data:image/png;base64,BBBB",
+        mime_type="image/png",
+        image_id="fake-image-id-2",
+    )
+
+    monkeypatch.setattr("views.main.run_generation_with_reference", lambda **kwargs: fake_result)
+
+    response = client.post(
+        "/",
+        data={
+            "mode": "chat_gui",
+            "chat_action": "generate",
+            "chat_mode": "reference_style_colorize",
+        },
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert "画像生成が完了しました。" in response.get_data(as_text=True)
+
+
+def test_chat_generate_edit(monkeypatch, client):
+    login(client)
+
+    fake_result = GenerationResult(
+        image_data_uri="data:image/png;base64,CCCC",
+        mime_type="image/png",
+        image_id="fake-image-id-3",
+    )
+
+    monkeypatch.setattr("views.main.run_edit_generation", lambda **kwargs: fake_result)
+
+    response = client.post(
+        "/",
+        data={
+            "mode": "chat_gui",
+            "chat_action": "generate",
+            "chat_mode": "inpaint_outpaint",
+            "chat_edit_mode": "inpaint",
+            "chat_edit_instruction": "修正",
+        },
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert "画像生成が完了しました。" in response.get_data(as_text=True)
+
+
+def test_existing_modes_work(monkeypatch, client):
+    login(client)
+
+    fake_result = GenerationResult(
+        image_data_uri="data:image/png;base64,DDDD",
+        mime_type="image/png",
+        image_id="fake-image-id-4",
+    )
+
+    monkeypatch.setattr("views.main.run_generation", lambda **kwargs: fake_result)
+    monkeypatch.setattr("views.main.run_generation_with_reference", lambda **kwargs: fake_result)
+    monkeypatch.setattr("views.main.run_edit_generation", lambda **kwargs: fake_result)
+
+    rough_response = client.post(
+        "/",
+        data={
+            "mode": "rough_with_instructions",
+            "color_instruction": "色",
+            "pose_instruction": "ポーズ",
+            "rough_image": (BytesIO(b"fake"), "rough.png"),
+        },
+        content_type="multipart/form-data",
+        follow_redirects=True,
+    )
+    assert rough_response.status_code == 200
+
+    reference_response = client.post(
+        "/",
+        data={
+            "mode": "reference_style_colorize",
+            "reference_image": (BytesIO(b"fake"), "ref.png"),
+            "rough_image": (BytesIO(b"fake"), "rough.png"),
+        },
+        content_type="multipart/form-data",
+        follow_redirects=True,
+    )
+    assert reference_response.status_code == 200
+
+    edit_response = client.post(
+        "/",
+        data={
+            "mode": "inpaint_outpaint",
+            "edit_base_image": (BytesIO(b"fake"), "base.png"),
+            "edit_mask_data": "data:image/png;base64,AAAA",
+            "edit_instruction": "修正",
+        },
+        content_type="multipart/form-data",
+        follow_redirects=True,
+    )
+    assert edit_response.status_code == 200

--- a/views/main.py
+++ b/views/main.py
@@ -5,21 +5,38 @@ from typing import Optional
 from flask import Blueprint, abort, current_app, flash, redirect, render_template, request, send_file, url_for
 from flask_login import current_user, login_required
 
-from illust import MissingApiKeyError
+from illust import MissingApiKeyError, generate_chat_response
 from extensions import db
 from models import IllustrationPreset
+from services.chat_service import (
+    ChatImage,
+    append_chat_message,
+    build_assistant_message,
+    build_chat_contents,
+    build_user_message,
+    clear_chat_history,
+    load_chat_history,
+)
 from services.generation_service import (
     GenerationError,
     extension_for_mime_type,
+    load_image_data_uri,
     load_image_path_from_session,
     load_mime_type_from_session,
     load_result_from_session,
+    persist_image_bytes,
     run_generation,
     run_generation_with_reference,
     run_edit_generation,
     save_result_to_session,
 )
-from services.modes import ALL_MODES, MODE_REFERENCE_STYLE_COLORIZE, MODE_INPAINT_OUTPAINT, normalize_mode_id
+from services.modes import (
+    ALL_MODES,
+    MODE_CHAT_GUI,
+    MODE_INPAINT_OUTPAINT,
+    MODE_REFERENCE_STYLE_COLORIZE,
+    normalize_mode_id,
+)
 
 
 main_bp = Blueprint("main", __name__)
@@ -55,45 +72,205 @@ def _fetch_presets() -> list[IllustrationPreset]:
 def index():
     image_data: Optional[str] = None
     current_mode = normalize_mode_id(request.form.get("mode") or request.args.get("mode"))
+    chat_history = load_chat_history()
 
     if request.method == "POST":
-        aspect_ratio_label = request.form.get("aspect_ratio") or "auto"
-        resolution_label = request.form.get("resolution") or "auto"
-
         try:
-            if current_mode == MODE_REFERENCE_STYLE_COLORIZE.id:
-                reference_file = request.files.get("reference_image")
-                rough_file = request.files.get("rough_image")
-                result = run_generation_with_reference(
-                    reference_file=reference_file,
-                    rough_file=rough_file,
-                    aspect_ratio_label=aspect_ratio_label,
-                    resolution_label=resolution_label,
-                )
-            elif current_mode == MODE_INPAINT_OUTPAINT.id:
-                base_file = request.files.get("edit_base_image")
-                base_data = request.form.get("edit_base_data", "")
-                mask_data = request.form.get("edit_mask_data", "")
-                edit_mode = request.form.get("edit_mode", "inpaint")
-                edit_instruction = request.form.get("edit_instruction", "")
-                result = run_edit_generation(
-                    base_file=base_file,
-                    base_data=base_data,
-                    mask_data=mask_data,
-                    edit_mode=edit_mode,
-                    edit_instruction=edit_instruction,
-                )
+            if current_mode == MODE_CHAT_GUI.id:
+                aspect_ratio_label = request.form.get("chat_aspect_ratio") or "auto"
+                resolution_label = request.form.get("chat_resolution") or "auto"
+                action = request.form.get("chat_action", "text")
+                if action == "clear":
+                    clear_chat_history()
+                    flash("チャット履歴をクリアしました。", "info")
+                    return redirect(url_for("main.index", mode=current_mode))
+
+                if action == "generate":
+                    chat_mode = normalize_mode_id(request.form.get("chat_mode"))
+                    if chat_mode == MODE_CHAT_GUI.id:
+                        flash("チャットメニューのモードが不正です。", "error")
+                        return redirect(url_for("main.index", mode=current_mode))
+
+                    if chat_mode == MODE_REFERENCE_STYLE_COLORIZE.id:
+                        reference_file = request.files.get("chat_reference_image")
+                        rough_file = request.files.get("chat_rough_image")
+
+                        user_images = []
+                        if rough_file and rough_file.filename:
+                            rough_bytes = rough_file.read()
+                            rough_mime = rough_file.mimetype or "image/png"
+                            rough_id = persist_image_bytes(raw_bytes=rough_bytes, mime_type=rough_mime)
+                            rough_file.stream.seek(0)
+                            user_images.append(ChatImage(image_id=rough_id, mime_type=rough_mime, label="ラフ"))
+                        if reference_file and reference_file.filename:
+                            reference_bytes = reference_file.read()
+                            reference_mime = reference_file.mimetype or "image/png"
+                            reference_id = persist_image_bytes(raw_bytes=reference_bytes, mime_type=reference_mime)
+                            reference_file.stream.seek(0)
+                            user_images.append(
+                                ChatImage(image_id=reference_id, mime_type=reference_mime, label="参照画像")
+                            )
+
+                        user_text = "メニュー: 完成絵参照→ラフ着色"
+                        chat_history = append_chat_message(
+                            chat_history,
+                            build_user_message(text=user_text, images=user_images),
+                        )
+
+                        result = run_generation_with_reference(
+                            reference_file=reference_file,
+                            rough_file=rough_file,
+                            aspect_ratio_label=aspect_ratio_label,
+                            resolution_label=resolution_label,
+                        )
+                    elif chat_mode == MODE_INPAINT_OUTPAINT.id:
+                        base_file = request.files.get("chat_edit_base_image")
+                        mask_file = request.files.get("chat_edit_mask_image")
+                        edit_mode = request.form.get("chat_edit_mode", "inpaint")
+                        edit_instruction = request.form.get("chat_edit_instruction", "")
+
+                        user_images = []
+                        if base_file and base_file.filename:
+                            base_bytes = base_file.read()
+                            base_mime = base_file.mimetype or "image/png"
+                            base_id = persist_image_bytes(raw_bytes=base_bytes, mime_type=base_mime)
+                            base_file.stream.seek(0)
+                            user_images.append(
+                                ChatImage(image_id=base_id, mime_type=base_mime, label="編集元画像")
+                            )
+                        if mask_file and mask_file.filename:
+                            mask_bytes = mask_file.read()
+                            mask_mime = mask_file.mimetype or "image/png"
+                            mask_id = persist_image_bytes(raw_bytes=mask_bytes, mime_type=mask_mime)
+                            mask_file.stream.seek(0)
+                            user_images.append(
+                                ChatImage(image_id=mask_id, mime_type=mask_mime, label="マスク画像")
+                            )
+
+                        user_text = f"メニュー: インペイント/アウトペイント編集（{edit_mode}）"
+                        if edit_instruction:
+                            user_text += f"\n指示: {edit_instruction}"
+                        chat_history = append_chat_message(
+                            chat_history,
+                            build_user_message(text=user_text, images=user_images),
+                        )
+
+                        result = run_edit_generation(
+                            base_file=base_file,
+                            base_data=None,
+                            mask_data=None,
+                            mask_file=mask_file,
+                            edit_mode=edit_mode,
+                            edit_instruction=edit_instruction,
+                        )
+                    else:
+                        rough_file = request.files.get("chat_rough_image")
+                        color_instruction = request.form.get("chat_color_instruction", "")
+                        pose_instruction = request.form.get("chat_pose_instruction", "")
+
+                        user_images = []
+                        if rough_file and rough_file.filename:
+                            rough_bytes = rough_file.read()
+                            rough_mime = rough_file.mimetype or "image/png"
+                            rough_id = persist_image_bytes(raw_bytes=rough_bytes, mime_type=rough_mime)
+                            rough_file.stream.seek(0)
+                            user_images.append(ChatImage(image_id=rough_id, mime_type=rough_mime, label="ラフ"))
+
+                        user_text = "メニュー: ラフ→仕上げ（色・ポーズ指示）"
+                        if color_instruction:
+                            user_text += f"\n色: {color_instruction}"
+                        if pose_instruction:
+                            user_text += f"\nポーズ: {pose_instruction}"
+                        chat_history = append_chat_message(
+                            chat_history,
+                            build_user_message(text=user_text, images=user_images),
+                        )
+
+                        result = run_generation(
+                            file=rough_file,
+                            color_instruction=color_instruction,
+                            pose_instruction=pose_instruction,
+                            aspect_ratio_label=aspect_ratio_label,
+                            resolution_label=resolution_label,
+                        )
+
+                    save_result_to_session(result)
+                    image_data = result.image_data_uri
+                    assistant_images = [
+                        ChatImage(
+                            image_id=result.image_id,
+                            mime_type=result.mime_type,
+                            label="生成結果",
+                        )
+                    ]
+                    chat_history = append_chat_message(
+                        chat_history,
+                        build_assistant_message("画像生成が完了しました。", images=assistant_images),
+                    )
+                    flash("チャットから生成リクエストを送信しました。", "success")
+                else:
+                    message_text = (request.form.get("chat_message") or "").strip()
+                    message_image = request.files.get("chat_image")
+                    if not message_text and (message_image is None or message_image.filename == ""):
+                        flash("テキストまたは画像を入力してください。", "error")
+                    else:
+                        images = []
+                        if message_image and message_image.filename:
+                            raw_bytes = message_image.read()
+                            mime_type = message_image.mimetype or "image/png"
+                            image_id = persist_image_bytes(raw_bytes=raw_bytes, mime_type=mime_type)
+                            images.append(ChatImage(image_id=image_id, mime_type=mime_type, label="ユーザー画像"))
+                            message_image.stream.seek(0)
+
+                        user_text = message_text or "画像を送信しました。"
+                        chat_history = append_chat_message(
+                            chat_history,
+                            build_user_message(text=user_text, images=images),
+                        )
+                        contents = build_chat_contents(chat_history)
+                        response_text = generate_chat_response(contents=contents)
+                        chat_history = append_chat_message(
+                            chat_history,
+                            build_assistant_message(response_text),
+                        )
             else:
-                file = request.files.get("rough_image")
-                color_instruction = request.form.get("color_instruction", "")
-                pose_instruction = request.form.get("pose_instruction", "")
-                result = run_generation(
-                    file=file,
-                    color_instruction=color_instruction,
-                    pose_instruction=pose_instruction,
-                    aspect_ratio_label=aspect_ratio_label,
-                    resolution_label=resolution_label,
-                )
+                aspect_ratio_label = request.form.get("aspect_ratio") or "auto"
+                resolution_label = request.form.get("resolution") or "auto"
+
+                if current_mode == MODE_REFERENCE_STYLE_COLORIZE.id:
+                    reference_file = request.files.get("reference_image")
+                    rough_file = request.files.get("rough_image")
+                    result = run_generation_with_reference(
+                        reference_file=reference_file,
+                        rough_file=rough_file,
+                        aspect_ratio_label=aspect_ratio_label,
+                        resolution_label=resolution_label,
+                    )
+                elif current_mode == MODE_INPAINT_OUTPAINT.id:
+                    base_file = request.files.get("edit_base_image")
+                    base_data = request.form.get("edit_base_data", "")
+                    mask_data = request.form.get("edit_mask_data", "")
+                    edit_mode = request.form.get("edit_mode", "inpaint")
+                    edit_instruction = request.form.get("edit_instruction", "")
+                    result = run_edit_generation(
+                        base_file=base_file,
+                        base_data=base_data,
+                        mask_data=mask_data,
+                        mask_file=None,
+                        edit_mode=edit_mode,
+                        edit_instruction=edit_instruction,
+                    )
+                else:
+                    file = request.files.get("rough_image")
+                    color_instruction = request.form.get("color_instruction", "")
+                    pose_instruction = request.form.get("pose_instruction", "")
+                    result = run_generation(
+                        file=file,
+                        color_instruction=color_instruction,
+                        pose_instruction=pose_instruction,
+                        aspect_ratio_label=aspect_ratio_label,
+                        resolution_label=resolution_label,
+                    )
         except GenerationError as exc:
             flash(str(exc), "error")
         except MissingApiKeyError:
@@ -103,9 +280,10 @@ def index():
             current_app.logger.exception("Image generation failed: %s", exc)
             flash("画像生成に失敗しました。しばらくしてから再試行してください。", "error")
         else:
-            save_result_to_session(result)
-            image_data = result.image_data_uri
-            flash("イラストの生成が完了しました。", "success")
+            if current_mode != MODE_CHAT_GUI.id:
+                save_result_to_session(result)
+                image_data = result.image_data_uri
+                flash("イラストの生成が完了しました。", "success")
 
     if not image_data:
         image_data = _restore_result()
@@ -121,6 +299,27 @@ def index():
         for preset in user_presets
     ]
 
+    chat_payload = []
+    for message in chat_history:
+        image_payloads = []
+        for image in message.images:
+            data_uri = load_image_data_uri(image.image_id, image.mime_type)
+            if not data_uri:
+                continue
+            image_payloads.append(
+                {
+                    "data_uri": data_uri,
+                    "label": image.label,
+                }
+            )
+        chat_payload.append(
+            {
+                "role": message.role,
+                "text": message.text,
+                "images": image_payloads,
+            }
+        )
+
     return render_template(
         "index.html",
         image_data=image_data,
@@ -130,6 +329,7 @@ def index():
         resolution_options=RESOLUTION_OPTIONS,
         user_presets=user_presets,
         presets_payload=presets_payload,
+        chat_history=chat_payload,
     )
 
 


### PR DESCRIPTION
### Motivation

- 既存の画像生成/編集モードを維持したまま、テキストベースのチャットインターフェース（Geminiライクな対話）をGUIから利用できるようにするため。 
- チャット中に既存のモード（ラフ→仕上げ、参照着色、インペイント/アウトペイント）をメニュー経由で呼び出せるようにして、マルチターンの編集ワークフローを実現するため。 
- 会話履歴を保持し、会話に基づく応答生成および画像生成結果を履歴として扱えるようにするため。

### Description

- 新しい生成モード `MODE_CHAT_GUI` を `services/modes.py` に追加し、既存モードは削除せず並列で提供しています。 
- チャット用ロジックを `services/chat_service.py` として追加し、セッションにチャット履歴（画像はIDで保存）を保持する仕組みを実装しました。 
- Geminiテキスト応答呼び出しを `illust.py` に `generate_chat_response` として追加し、レスポンスからテキストを抽出するユーティリティを実装しました。 
- 画像保存/読み出しやData URI生成、編集モードのマスク取り扱いを `services/generation_service.py` に追加・拡張し、チャット経由でアップロードされた画像を一時保存して参照できるようにしました。 
- フロントエンドにチャットUIを `templates/index.html`（会話履歴表示、メニュー、モード別パネル）として追加し、JS (`static/js/index.js`) と CSS (`static/css/index.css`) を拡張して表示切替・送信状態管理を行います。 
- サーバ側の分岐を `views/main.py` の `index` に実装し、チャットのテキスト送信・メニュー経由の生成実行・履歴クリアを扱います。 
- テストを `tests/test_chat_mode.py` に追加し、既存モードのPOST分岐含めた基本的なシナリオをモンキーパッチで検証します。 
- 開発用: `app.create_app` に `config_override` 引数を追加してテスト起動時の設定注入を容易にしました。 
- ドキュメント: `.agent/EXEC_PLAN_CHAT_GUI.md` を追加して実装計画と決定ログを残しました。 

### Testing

- 自動テストは `pytest` を実行し、追加した `tests/test_chat_mode.py` を含む 5 件のテストがすべてパスしました（`pytest` 実行結果: 5 passed）。
- テスト実行中に SQLAlchemy の `LegacyAPIWarning` が表示されましたが、テストは成功しています。
- 追加したテストはチャットテキスト送信時の応答フローと、チャット経由での各生成モード（ラフ生成、参照着色、編集）のPOST処理をモンキーパッチで検証します。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6956d57413088326ba3d92c9741f5763)