### PR TITLE
ステッパーUI追加とステップ表記の整合

### DIFF
--- a/static/css/index.css
+++ b/static/css/index.css
@@ -46,6 +46,62 @@
   font-size: 0.9rem;
 }
 
+.stepper {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 20px;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.stepper-item {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: rgba(219, 229, 255, 0.72);
+  font-size: 0.95rem;
+}
+
+.stepper-item::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  right: -14px;
+  width: 12px;
+  height: 1px;
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.stepper-item:last-child::after {
+  display: none;
+}
+
+.stepper-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(219, 229, 255, 0.9);
+  font-weight: 600;
+}
+
+.stepper-item.is-current {
+  color: #f4fbff;
+}
+
+.stepper-item.is-current .stepper-badge {
+  border-color: rgba(31, 209, 249, 0.6);
+  background: rgba(31, 209, 249, 0.2);
+  color: #b8ecff;
+  box-shadow: 0 0 0 3px rgba(31, 209, 249, 0.15);
+}
+
 .meta-label {
   color: #a8b3d7;
   font-size: 0.95rem;

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,6 +10,24 @@
       <span class="badge badge-soft">ローディング表示</span>
     </div>
     <h1 class="hero-title mb-2">モードを切り替えて、ラフを高品質イラストへ</h1>
+    <ol class="stepper mb-3" aria-label="利用ステップ">
+      <li class="stepper-item is-current">
+        <span class="stepper-badge">1</span>
+        <span class="stepper-label">モード選択</span>
+      </li>
+      <li class="stepper-item">
+        <span class="stepper-badge">2</span>
+        <span class="stepper-label">ファイル/指示入力</span>
+      </li>
+      <li class="stepper-item">
+        <span class="stepper-badge">3</span>
+        <span class="stepper-label">送信</span>
+      </li>
+      <li class="stepper-item">
+        <span class="stepper-badge">4</span>
+        <span class="stepper-label">結果確認</span>
+      </li>
+    </ol>
     <p class="subtle-text mb-3">ラフ1枚＋指示、または完成絵参照＋ラフ（2枚）で、Gemini に仕上げを依頼します。プレビューで確認しながら安心して送信できます。</p>
     <div class="d-flex flex-wrap gap-2">
       <div class="pill"><i class="bi bi-magic"></i> ブラシアップと欠損補完</div>
@@ -25,7 +43,7 @@
       <div class="card-body">
         <div class="d-flex align-items-center justify-content-between mb-3">
           <h2 class="card-title mb-0">生成リクエスト</h2>
-          <span class="option-chip"><i class="bi bi-check2-circle"></i> ステップ 1</span>
+          <span class="option-chip"><i class="bi bi-pencil-square"></i> ファイル/指示入力</span>
         </div>
 
         <div class="mode-switch mb-3">
@@ -267,7 +285,7 @@
           <h3 class="card-title mb-0">生成されたイラスト</h3>
           <div class="d-flex align-items-center gap-2">
             <span class="badge badge-soft" id="generationStatusBadge">{{ '完了' if image_data else '待機中' }}</span>
-            <span class="option-chip"><i class="bi bi-download"></i> ステップ 2</span>
+            <span class="option-chip"><i class="bi bi-image"></i> 結果確認</span>
           </div>
         </div>
         <div class="small text-white-50 mb-3" id="generationStatusText">


### PR DESCRIPTION
### Motivation
- 利用開始時に画面上で手順を明確に示しユーザビリティを向上させるため、ヒーロー領域にステップ型ガイドを追加しました。 
- 既存の `option-chip` 表記をステッパーのステップ名称と整合させて一貫性を持たせるための変更です。 
- 現在のステップが視覚的に識別できるように強調表示を実装してユーザーの操作を誘導します。 

### Description
- `templates/index.html` の `hero-title` 直下に4段階（「モード選択」「ファイル/指示入力」「送信」「結果確認」）のステッパーを追加しました。 
- `static/css/index.css` に `.stepper`, `.stepper-item`, `.stepper-badge`, `.stepper-item.is-current` 等のスタイルを追加し現在ステップの強調表示を実装しました。 
- `templates/index.html` 内の `option-chip` 表記をステッパーに合わせて文言とアイコンを更新しました（例: `ステップ 1` → `ファイル/指示入力`, `ステップ 2` → `結果確認`）。 
- ロジックやバックエンドの挙動は変更しておらず、UI/CSS のみの改修です。 

### Testing
- `pip install -r requirements.txt` を実行して依存をインストールし、インストールは成功しました。 
- `flask --app app.py run` でアプリを起動してサーバが起動することを確認し、起動は成功しました。 
- Playwright スクリプトでルートページにアクセスしてスクリーンショット `artifacts/stepper.png` を取得し、ステッパー表示を確認しました（成功）。 
- 本変更は UI の見た目変更が中心のため、自動化されたユニットテストは実行していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695795824bdc8326a7752bffd65c1fa7)