### PR TITLE
モード選択をカード型ラジオUIに変更

### DIFF
--- a/static/css/index.css
+++ b/static/css/index.css
@@ -150,28 +150,95 @@
   padding: 12px;
 }
 
-.mode-pills {
+.mode-card-group {
+  display: grid;
+  gap: 12px;
+}
+
+.mode-card {
+  display: block;
+  cursor: pointer;
+  margin: 0;
+  position: relative;
+}
+
+.mode-card-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.mode-card-body {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
+  gap: 8px;
+  padding: 14px 16px;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.04);
+  transition: border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.mode-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  font-weight: 600;
+  color: #f4fbff;
+}
+
+.mode-card-title {
+  font-size: 1rem;
+}
+
+.mode-card-badge {
+  font-size: 0.78rem;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  color: rgba(219, 229, 255, 0.85);
+}
+
+.mode-card-description {
+  color: rgba(219, 229, 255, 0.8);
+  font-size: 0.92rem;
+}
+
+.mode-card-meta {
+  display: grid;
+  gap: 6px;
+  font-size: 0.9rem;
+  color: rgba(219, 229, 255, 0.75);
+}
+
+.mode-card-row {
+  display: grid;
+  grid-template-columns: 90px 1fr;
   gap: 8px;
 }
 
-.mode-pills .nav-link {
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.06);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  color: #dfe5ff;
-  padding: 8px 12px;
+.mode-card-label {
+  color: rgba(219, 229, 255, 0.6);
 }
 
-.mode-pills .nav-link.active {
-  background: rgba(31, 209, 249, 0.14);
-  border-color: rgba(31, 209, 249, 0.35);
-  color: #b8ecff;
+.mode-card-value {
+  color: rgba(219, 229, 255, 0.9);
 }
 
-.mode-pills .nav-link.disabled {
+.mode-card.is-active .mode-card-body {
+  border-color: rgba(31, 209, 249, 0.6);
+  background: rgba(31, 209, 249, 0.12);
+  box-shadow: 0 0 0 3px rgba(31, 209, 249, 0.12);
+}
+
+.mode-card.is-disabled {
   opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.mode-card.is-disabled .mode-card-body {
+  background: rgba(255, 255, 255, 0.02);
 }
 
 

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -149,12 +149,12 @@ const MODE_SUBMIT_LABELS = {
 };
 
 const initModeSwitch = (uploaders) => {
-  const modePills = document.getElementById('modePills');
+  const modeCards = document.getElementById('modeCards');
   const modeInput = document.getElementById('generationModeInput');
   const modeDescription = document.getElementById('modeDescription');
   const submitLabel = document.getElementById('submitLabel');
 
-  if (!modePills || !modeInput) return;
+  if (!modeCards || !modeInput) return;
 
   const splitModes = (raw) =>
     String(raw || '')
@@ -186,9 +186,12 @@ const initModeSwitch = (uploaders) => {
       input.value = modeId;
     });
 
-    const buttons = modePills.querySelectorAll('button[data-mode]');
-    buttons.forEach((btn) => {
-      btn.classList.toggle('active', btn.dataset.mode === modeId);
+    const inputs = modeCards.querySelectorAll('input[data-mode]');
+    inputs.forEach((input) => {
+      const isActive = input.dataset.mode === modeId;
+      input.checked = isActive;
+      const card = input.closest('.mode-card');
+      if (card) card.classList.toggle('is-active', isActive);
     });
 
     toggleVisibility(modeId);
@@ -197,8 +200,8 @@ const initModeSwitch = (uploaders) => {
       submitLabel.textContent = MODE_SUBMIT_LABELS[modeId];
     }
 
-    const activeButton = modePills.querySelector(`button[data-mode="${modeId}"]`);
-    const description = activeButton ? activeButton.dataset.modeDescription : '';
+    const activeInput = modeCards.querySelector(`input[data-mode="${modeId}"]`);
+    const description = activeInput ? activeInput.dataset.modeDescription : '';
     if (modeDescription) modeDescription.textContent = description || '';
 
     if (uploaders && uploaders.reference && modeId !== 'reference_style_colorize') {
@@ -220,10 +223,10 @@ const initModeSwitch = (uploaders) => {
     if (updateUrl) setModeInUrl(modeId);
   };
 
-  modePills.querySelectorAll('button[data-mode]').forEach((btn) => {
-    btn.addEventListener('click', () => {
-      if (btn.disabled) return;
-      applyMode(btn.dataset.mode);
+  modeCards.querySelectorAll('input[data-mode]').forEach((input) => {
+    input.addEventListener('change', () => {
+      if (input.disabled) return;
+      applyMode(input.dataset.mode);
     });
   });
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -70,17 +70,57 @@
                   </small>
                 </div>
               </div>
-              <div class="nav nav-pills mode-pills" id="modePills" role="tablist" aria-label="生成モード">
+              <div class="mode-card-group" id="modeCards" role="radiogroup" aria-label="生成モード">
                 {% for mode in modes %}
-                <button
-                  type="button"
-                  class="nav-link {% if mode.id == current_mode %}active{% endif %} {% if not mode.enabled %}disabled{% endif %}"
-                  data-mode="{{ mode.id }}"
-                  data-mode-description="{{ mode.description }}"
-                  {% if not mode.enabled %}disabled aria-disabled="true"{% endif %}
-                >
-                  {{ mode.label }}
-                </button>
+                {% if mode.id == 'rough_with_instructions' %}
+                {% set mode_usage = 'ラフから仕上げを指示したいとき' %}
+                {% set mode_required = 'ラフスケッチ1枚' %}
+                {% set mode_result = '指示に沿った仕上げイラスト' %}
+                {% elif mode.id == 'reference_style_colorize' %}
+                {% set mode_usage = '完成絵のタッチでラフを仕上げたいとき' %}
+                {% set mode_required = '完成絵1枚＋ラフ1枚' %}
+                {% set mode_result = '参照絵柄に合わせた着色・仕上げ' %}
+                {% elif mode.id == 'inpaint_outpaint' %}
+                {% set mode_usage = '一部修正や余白の拡張をしたいとき' %}
+                {% set mode_required = '編集対象画像1枚（マスク使用）' %}
+                {% set mode_result = '指定範囲のみ修正/拡張' %}
+                {% else %}
+                {% set mode_usage = '' %}
+                {% set mode_required = '' %}
+                {% set mode_result = '' %}
+                {% endif %}
+                <label class="mode-card {% if mode.id == current_mode %}is-active{% endif %} {% if not mode.enabled %}is-disabled{% endif %}">
+                  <input
+                    type="radio"
+                    name="mode-card"
+                    class="mode-card-input"
+                    data-mode="{{ mode.id }}"
+                    data-mode-description="{{ mode.description }}"
+                    {% if mode.id == current_mode %}checked{% endif %}
+                    {% if not mode.enabled %}disabled aria-disabled="true"{% endif %}
+                  >
+                  <span class="mode-card-body">
+                    <span class="mode-card-header">
+                      <span class="mode-card-title">{{ mode.label }}</span>
+                      {% if not mode.enabled %}<span class="mode-card-badge">準備中</span>{% endif %}
+                    </span>
+                    <span class="mode-card-description">{{ mode.description }}</span>
+                    <span class="mode-card-meta">
+                      <span class="mode-card-row">
+                        <span class="mode-card-label">用途</span>
+                        <span class="mode-card-value">{{ mode_usage }}</span>
+                      </span>
+                      <span class="mode-card-row">
+                        <span class="mode-card-label">必要画像</span>
+                        <span class="mode-card-value">{{ mode_required }}</span>
+                      </span>
+                      <span class="mode-card-row">
+                        <span class="mode-card-label">結果</span>
+                        <span class="mode-card-value">{{ mode_result }}</span>
+                      </span>
+                    </span>
+                  </span>
+                </label>
                 {% endfor %}
               </div>
             </div>


### PR DESCRIPTION
### Motivation
- モード選択UIをより情報量の多いカード形式にして、各モードの用途や必要画像、期待結果を明示するため。 
- ユーザがモード選択時に必要な入力項目や挙動を直感的に理解できるようにするため。

### Description
- `templates/index.html` の既存 `mode-pills` をカード型ラジオUI（`mode-card-group` / `mode-card`）に置き換えし、各モードカード内に `用途` / `必要画像` / `結果` の3行説明を追加しました。  
- 各カードのラベル入力に `data-mode` と `data-mode-description` を保持し、カード内にもモード説明を表示するようにしました。  
- `static/css/index.css` にカードUIのスタイルを追加し、アクティブ状態の枠色・背景（`.mode-card.is-active`）と無効状態（`.mode-card.is-disabled`）のスタイルを定義しました。  
- `static/js/index.js` のモード切替ロジックを新しいカード要素に紐付け、`modePills` 参照を `modeCards` に置換して `input[data-mode]` の `change` イベントで `applyMode` を呼ぶよう更新しました。

### Testing
- 自動化されたユニット/統合テストは実行していません（UI変更のため）。
- ブラウザでの手動確認は今回のコミットログに含めていません（ログインが必要なため）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6957987a9c588326b7f1018ed7c19aa7)