### PR TITLE
ドロップゾーンに状態表示とヘルプ行を追加（状態クラスで色/アイコン表示）

### DIFF
--- a/static/css/index.css
+++ b/static/css/index.css
@@ -7,9 +7,54 @@
   transition: border-color 0.2s ease, background 0.2s ease;
 }
 
+.upload-dropzone.is-ready {
+  border-color: rgba(255, 255, 255, 0.35);
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.upload-dropzone.has-file {
+  border-color: rgba(115, 217, 132, 0.8);
+  background: rgba(74, 197, 98, 0.12);
+}
+
+.upload-dropzone.has-error {
+  border-color: rgba(255, 99, 99, 0.9);
+  background: rgba(255, 70, 70, 0.12);
+}
+
 .upload-dropzone.hover {
   border-color: var(--accent);
   background: rgba(31, 209, 249, 0.08);
+}
+
+.upload-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(12, 15, 26, 0.35);
+  color: rgba(219, 229, 255, 0.9);
+}
+
+.upload-status-icon {
+  font-size: 0.7rem;
+}
+
+.upload-dropzone.is-ready .upload-status-icon {
+  color: rgba(219, 229, 255, 0.7);
+}
+
+.upload-dropzone.has-file .upload-status-icon {
+  color: #57d17a;
+}
+
+.upload-dropzone.has-error .upload-status-icon {
+  color: #ff6b6b;
+}
+
+.upload-help {
+  line-height: 1.4;
 }
 
 .preview-image {

--- a/templates/index.html
+++ b/templates/index.html
@@ -190,6 +190,11 @@
                   <div id="referencePlaceholder" class="subtle-text mb-2">参考画像をドラッグ＆ドロップ、または下のボタンから選択</div>
                   <img id="referencePreviewImage" class="preview-image d-none mb-2" alt="参考画像プレビュー">
                   <div id="referenceFileMeta" class="small text-white-50 mb-2"></div>
+                  <div class="upload-status small mb-1">
+                    <i class="bi bi-circle-fill upload-status-icon" id="referenceStatusIcon" aria-hidden="true"></i>
+                    <span id="referenceStatusText">未選択</span>
+                  </div>
+                  <div class="upload-help small text-white-50 mb-2">許容拡張子: PNG/JPG/JPEG・推奨サイズ: 長辺1024px以上</div>
                   <div class="d-flex justify-content-center gap-2">
                     <label class="btn btn-outline-light btn-sm" for="reference_image"><i class="bi bi-folder2-open me-1"></i> ファイルを選択</label>
                     <button class="btn btn-outline-light btn-sm" type="button" id="referenceClearImage" aria-label="参考画像をクリア"><i class="bi bi-x-lg"></i></button>
@@ -206,6 +211,11 @@
                   <div id="roughPlaceholder" class="subtle-text mb-2">画像をドラッグ＆ドロップ、または下のボタンから選択</div>
                   <img id="roughPreviewImage" class="preview-image d-none mb-2" alt="ラフ画像プレビュー">
                   <div id="roughFileMeta" class="small text-white-50 mb-2"></div>
+                  <div class="upload-status small mb-1">
+                    <i class="bi bi-circle-fill upload-status-icon" id="roughStatusIcon" aria-hidden="true"></i>
+                    <span id="roughStatusText">未選択</span>
+                  </div>
+                  <div class="upload-help small text-white-50 mb-2">許容拡張子: PNG/JPG/JPEG・推奨サイズ: 長辺1024px以上</div>
                   <div class="d-flex justify-content-center gap-2">
                     <label class="btn btn-outline-light btn-sm" for="rough_image"><i class="bi bi-folder2-open me-1"></i> ファイルを選択</label>
                     <button class="btn btn-outline-light btn-sm" type="button" id="roughClearImage" aria-label="ラフ画像をクリア"><i class="bi bi-x-lg"></i></button>
@@ -230,6 +240,11 @@
                     <div id="editBasePlaceholder" class="subtle-text mb-2">画像をドラッグ＆ドロップ、または下のボタンから選択</div>
                     <img id="editBasePreviewImage" class="preview-image d-none mb-2" alt="編集対象画像プレビュー">
                     <div id="editBaseFileMeta" class="small text-white-50 mb-2"></div>
+                    <div class="upload-status small mb-1">
+                      <i class="bi bi-circle-fill upload-status-icon" id="editBaseStatusIcon" aria-hidden="true"></i>
+                      <span id="editBaseStatusText">未選択</span>
+                    </div>
+                    <div class="upload-help small text-white-50 mb-2">許容拡張子: PNG/JPG/JPEG・推奨サイズ: 長辺1024px以上</div>
                     <div class="d-flex justify-content-center gap-2">
                       <label class="btn btn-outline-light btn-sm" for="edit_base_image"><i class="bi bi-folder2-open me-1"></i> ファイルを選択</label>
                       <button class="btn btn-outline-light btn-sm" type="button" id="editBaseClearImage" aria-label="編集対象画像をクリア"><i class="bi bi-x-lg"></i></button>
@@ -243,6 +258,11 @@
                     <div id="editMaskPlaceholder" class="subtle-text mb-2">エディタで作成したマスクがここに表示されます</div>
                     <img id="editMaskPreviewImage" class="preview-image d-none mb-2" alt="マスク画像プレビュー">
                     <div id="editMaskFileMeta" class="small text-white-50 mb-2"></div>
+                    <div class="upload-status small mb-1">
+                      <i class="bi bi-circle-fill upload-status-icon" id="editMaskStatusIcon" aria-hidden="true"></i>
+                      <span id="editMaskStatusText">未選択</span>
+                    </div>
+                    <div class="upload-help small text-white-50">許容拡張子: PNG（エディタ生成）・推奨サイズ: 編集対象と同じ</div>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
### Motivation
- ユーザーが各ファイルドロップゾーンの状態（未選択/選択済み/エラー）と許容形式・推奨サイズを一目で確認できるようにするため。 
- ドロップゾーンの状態に応じて視覚的フィードバック（色・アイコン）を付与して操作性を向上させるため。 
- ファイル選択時に状態を動的に切り替え、誤った形式のファイル選択をわかりやすく通知するため。 

### Description
- `templates/index.html` に各ドロップゾーン（参考画像/ラフ/編集対象/マスク）へ状態表示要素（アイコン・テキスト）と許容拡張子・推奨サイズのヘルプ行を追加しました。 
- `static/css/index.css` にドロップゾーン状態クラス `.is-ready`, `.has-file`, `.has-error` と、それに連動する `upload-status`/`upload-help` スタイルを追加しました。 
- `static/js/index.js` に `createDropzoneStatus` を追加し、`bindImageUploader` を拡張して状態テキスト・アイコンの更新、受入形式チェック（`acceptedTypes`）・エラーハンドリングを行うようにしました。 
- マスクエディタ処理を更新して、マスク適用時にマスクドロップゾーンの状態を `選択済み` に切り替えるように `initMaskEditor` の呼び出しを調整しました。 

### Testing
- ローカルで `python app.py` を実行して起動を試みましたが、`ModuleNotFoundError: No module named 'flask'` により起動できず自動確認は失敗しました。 
- `flask --app app.py run` も同様に `flask` コマンドが存在せず実行できませんでした。 
- 変更はリポジトリに追加され `git commit` によりコミット済みです（ビルド/統合テストは未実行）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69579c69aae88326a7773b9ed0830f45)