### PR TITLE
生成カードの空状態とローディングバーを追加

### DIFF
--- a/static/css/index.css
+++ b/static/css/index.css
@@ -160,6 +160,66 @@
   animation: shimmer 1.2s infinite;
 }
 
+.generation-loading-bar {
+  margin: 12px 0 4px;
+}
+
+.empty-illustration-state {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 16px;
+  padding: 24px 20px;
+  text-align: center;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.empty-illustration-icon {
+  width: 92px;
+  height: 92px;
+  margin: 0 auto 12px;
+  color: rgba(184, 236, 255, 0.8);
+}
+
+.empty-illustration-icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+.empty-steps {
+  list-style: none;
+  padding: 0;
+  margin: 12px auto 16px;
+  max-width: 260px;
+  display: grid;
+  gap: 8px;
+  text-align: left;
+  color: rgba(219, 229, 255, 0.85);
+  font-size: 0.92rem;
+  counter-reset: empty-step;
+}
+
+.empty-steps li {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.empty-steps li::before {
+  content: counter(empty-step);
+  counter-increment: empty-step;
+  width: 22px;
+  height: 22px;
+  flex: 0 0 22px;
+  border-radius: 50%;
+  background: rgba(31, 209, 249, 0.18);
+  border: 1px solid rgba(31, 209, 249, 0.35);
+  color: #b8ecff;
+  font-weight: 600;
+  font-size: 0.8rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
 @keyframes shimmer {
   0% {
     filter: brightness(0.8);

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -336,8 +336,15 @@ const initSubmitState = () => {
   const submitLabel = document.getElementById('submitLabel');
   const statusBadge = document.getElementById('generationStatusBadge');
   const statusText = document.getElementById('generationStatusText');
+  const loadingBar = document.getElementById('generationLoadingBar');
 
   if (!form || !submitBtn || !spinner || !submitLabel) return;
+
+  const syncLoadingBar = () => {
+    if (!loadingBar || !statusBadge) return;
+    const isGenerating = statusBadge.textContent.trim() === '生成中';
+    loadingBar.classList.toggle('d-none', !isGenerating);
+  };
 
   form.addEventListener('submit', () => {
     submitBtn.disabled = true;
@@ -345,7 +352,10 @@ const initSubmitState = () => {
     submitLabel.textContent = '送信中...';
     if (statusBadge) statusBadge.textContent = '生成中';
     if (statusText) statusText.textContent = '生成中です。しばらくお待ちください。';
+    syncLoadingBar();
   });
+
+  syncLoadingBar();
 };
 
 const initPresets = () => {

--- a/templates/index.html
+++ b/templates/index.html
@@ -385,6 +385,7 @@
         <div class="small text-white-50 mb-3" id="generationStatusText">
           {{ '生成が完了しました。' if image_data else 'ここに生成結果が表示されます。' }}
         </div>
+        <div class="loading-bar generation-loading-bar d-none" id="generationLoadingBar" aria-hidden="true"></div>
         {% if image_data %}
         <div class="text-center">
           <img class="img-fluid rounded mb-3" src="{{ image_data }}" alt="生成イラスト">
@@ -393,15 +394,31 @@
           </div>
         </div>
         {% else %}
-        <p class="subtle-text mb-0 {% if current_mode != 'rough_with_instructions' %}d-none{% endif %}" data-mode-visible="rough_with_instructions">
-          ラフスケッチをアップロードして「イラスト生成」を押すと、ここにプレビューが表示されます。
-        </p>
-        <p class="subtle-text mb-0 {% if current_mode != 'reference_style_colorize' %}d-none{% endif %}" data-mode-visible="reference_style_colorize">
-          参考（完成）画像とラフスケッチをアップロードして「参照して着色」を押すと、ここにプレビューが表示されます。
-        </p>
-        <p class="subtle-text mb-0 {% if current_mode != 'inpaint_outpaint' %}d-none{% endif %}" data-mode-visible="inpaint_outpaint">
-          編集対象画像をアップロードしてマスクを描き、「編集をリクエスト」を押すと、ここにプレビューが表示されます。
-        </p>
+        <div class="empty-illustration-state">
+          <div class="empty-illustration-icon" aria-hidden="true">
+            <svg viewBox="0 0 96 96" role="presentation" focusable="false">
+              <rect x="14" y="18" width="68" height="60" rx="12" ry="12" fill="none" stroke="currentColor" stroke-width="3"></rect>
+              <circle cx="36" cy="42" r="6" fill="currentColor" opacity="0.6"></circle>
+              <path d="M26 70l18-22 14 16 12-12 12 18" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" opacity="0.8"></path>
+            </svg>
+          </div>
+          <h4 class="mb-2">まだ生成結果がありません</h4>
+          <ol class="empty-steps">
+            <li>モードを選択</li>
+            <li>画像を追加</li>
+            <li>指示を入力</li>
+            <li>生成をリクエスト</li>
+          </ol>
+          <p class="subtle-text mb-0 {% if current_mode != 'rough_with_instructions' %}d-none{% endif %}" data-mode-visible="rough_with_instructions">
+            ラフスケッチをアップロードして「イラスト生成」を押すと、ここにプレビューが表示されます。
+          </p>
+          <p class="subtle-text mb-0 {% if current_mode != 'reference_style_colorize' %}d-none{% endif %}" data-mode-visible="reference_style_colorize">
+            参考（完成）画像とラフスケッチをアップロードして「参照して着色」を押すと、ここにプレビューが表示されます。
+          </p>
+          <p class="subtle-text mb-0 {% if current_mode != 'inpaint_outpaint' %}d-none{% endif %}" data-mode-visible="inpaint_outpaint">
+            編集対象画像をアップロードしてマスクを描き、「編集をリクエスト」を押すと、ここにプレビューが表示されます。
+          </p>
+        </div>
         {% endif %}
       </div>
     </div>


### PR DESCRIPTION
### Motivation
- 生成結果領域が未生成時に何をすればよいか分かるよう、空状態の案内を追加するため。 
- 生成中は視覚的に進行を示すため、カード内にローディングバーを表示するため。 
- 空状態の見た目を中央寄せ・淡い枠で整えてUIを改善するため。

### Description
- `templates/index.html` に空状態のブロックを追加し、SVGアイコンと簡潔な手順リスト（モード選択→画像追加→指示入力→生成リクエスト）を追加した。 
- 同テンプレートにカード内ローディングバー用の要素 `<div id="generationLoadingBar" class="loading-bar generation-loading-bar d-none">` を配置して `generationStatusBadge` と連動させる基盤を用意した。 
- `static/css/index.css` に空状態用のスタイル（`.empty-illustration-state`, `.empty-illustration-icon`, `.empty-steps`, `.generation-loading-bar` など）を追加し、中央寄せ・淡い枠で表示されるようにした。 
- `static/js/index.js` の `initSubmitState` にローディングバー同期処理 `syncLoadingBar` を追加し、送信時に `generationStatusBadge` の値が `生成中` のときローディングバーを表示するようにした（初期同期も実行）。

### Testing
- `pip install -r requirements.txt` を実行して依存関係のインストールが成功したことを確認した（成功）。
- 開発サーバーを `flask --app app.py run` で起動しアプリが立ち上がることを確認した（起動は成功）。
- UIのスクリーンショット取得を自動化するために Playwright を使った検証を試みたが、Chromium の起動/クラッシュによりスクリーンショット取得は失敗した（失敗）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6957a1d403dc8326b0dec02770a01335)